### PR TITLE
Support hash_including

### DIFF
--- a/lib/graphiti_spec_helpers/node.rb
+++ b/lib/graphiti_spec_helpers/node.rb
@@ -27,6 +27,7 @@ module GraphitiSpecHelpers
     def has_key?(key)
       @attributes.has_key?(key)
     end
+    alias :key? :has_key?
 
     def [](key)
       @attributes[key] || @attributes[key.to_s]


### PR DESCRIPTION
Test helpers (like rspec's hash_including) like to check for key? when doing fuzzy hash-like assertions. This alias ensures Node instances are treated like hashes for these fuzzy comparisons.